### PR TITLE
explicitly load lapack with RTLD_GLOBAL

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,13 @@ using BinDeps
 
 @BinDeps.setup
 
-scs = library_dependency("scs", aliases=["libscsdir64","libscsdir"])
+if (@osx? (Base.blas_vendor() == :openblas64) : false)
+    aliases = ["libscsdir64"]
+else
+    aliases = ["libscsdir"]
+end
+
+scs = library_dependency("scs", aliases=aliases)
 
 @osx_only begin
     using Homebrew

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -6,6 +6,11 @@ else
     error("SCS not properly installed. Please run Pkg.build(\"SCS\") and restart julia")
 end
 
+function __init__()
+    # default binaries need access to Julia's lapack symbols
+    @unix_only dlopen(Base.liblapack_name, RTLD_LAZY|RTLD_DEEPBIND|RTLD_GLOBAL)
+end
+
 include("types.jl")
 include("low_level_wrapper.jl")
 include("high_level_wrapper.jl")

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -113,5 +113,4 @@ function feasible_sdp_conic()
     @assert sol.ret_val == 1
 end
 
-# Comment this out if you have BLAS/LAPACK working
-# feasible_sdp_conic();
+feasible_sdp_conic();


### PR DESCRIPTION
We hadn't been testing the SCS functionality which calls lapack, oops.
@tkelman @staticfloat, is this a reasonable fix? Not sure how else to enable SCS to find julia's lapack symbols. It should be safe to load these globally now that the 64-bit integer API won't cause name clashes.
CC @karanveerm 