### PR TITLE
Update max_iters + fix deprec warning

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.3
 MathProgBase
 BinDeps
 @osx Homebrew
+Compat

--- a/src/high_level_wrapper.jl
+++ b/src/high_level_wrapper.jl
@@ -23,8 +23,8 @@ end
 # c is of length n x 1
 # refer to create_scs_cone for K
 function create_scs_data(;m::Int=nothing, n::Int=nothing, A::Ptr{SCSMatrix}=nothing,
-        b::Ptr{Cdouble}=nothing,  c::Ptr{Cdouble}=nothing, max_iters=2500::Int,
-        eps=convert(Cdouble, 1e-5)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
+        b::Ptr{Cdouble}=nothing,  c::Ptr{Cdouble}=nothing, max_iters=20000::Int,
+        eps=convert(Cdouble, 1e-4)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
         rho_x=convert(Cdouble, 1e-3)::Cdouble, scale=convert(Cdouble, 5.0)::Cdouble,
         cg_rate=convert(Cdouble, 1.5)::Cdouble, verbose=1::Int,
         normalize=1::Int, warm_start=0::Int, options...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -100,13 +100,13 @@ immutable SCSWork
     p::Ptr{Void}
 end
 
-const status_map = {
+const status_map = Dict{Int, Symbol}(
     1 => :Optimal,
     -2 => :Infeasible,
     -1 => :Unbounded,
     -3 => :Indeterminate,
     -4 => :Error
-}
+)
 
 type Solution
     x::Array{Float64, 1}

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,4 @@
+using Compat
 export SCSMatrix, SCSData, SCSSolution, SCSInfo, SCSCone, SCSWork, SCSVecOrMatOrSparse
 
 
@@ -100,7 +101,7 @@ immutable SCSWork
     p::Ptr{Void}
 end
 
-const status_map = Dict{Int, Symbol}(
+@compat const status_map = Dict{Int, Symbol}(
     1 => :Optimal,
     -2 => :Infeasible,
     -1 => :Unbounded,


### PR DESCRIPTION
cc @madeleineudell @davidlizeng @jennyhong 

Throughout [EE364A](http://web.stanford.edu/class/ee364a/), we have been running into issues where the problem solution is inaccurate because max_iters has been too small (and also outside of EE364A: https://github.com/JuliaOpt/Convex.jl/issues/64 or [time series](http://nbviewer.ipython.org/github/JuliaOpt/Convex.jl/blob/master/examples/time_series/time_series.ipynb)).

Prof. Boyd really wants us to make `max_iters` 20k by default and change `eps` to `1e-4`. 

Also get rid of deprec warning.