### PR TITLE
take out sign flipping, closes #40

### DIFF
--- a/src/SCSSolverInterface.jl
+++ b/src/SCSSolverInterface.jl
@@ -473,15 +473,8 @@ end
 supportedcones(s::SCSSolver) = [:Free, :Zero, :NonNeg, :NonPos, :SOC, :SDP, :ExpPrimal, :ExpDual]
 
 function getconicdual(m::SCSMathProgModel)
-    # TODO: Why am I flipping signs? Also, do I need to flip the signs for every cone that isnt NonNeg?
-    # Flipping signs seems to make it pass the MPB dual tests
     dual = m.dual_sol[m.row_map_ind]
-    for i in 1:length(m.row_map_type)
-        if m.row_map_type[i] != :NonNeg
-            dual[i] = -dual[i]
-        end
-    end
-    # reverse the rescaling of the SDP variables
+    # undo the rescaling of the SDP variables
     if !((:rescale, false) in m.options)
         rescaleconicdual!(m, dual)
     end

--- a/src/SCSSolverInterface.jl
+++ b/src/SCSSolverInterface.jl
@@ -474,6 +474,12 @@ supportedcones(s::SCSSolver) = [:Free, :Zero, :NonNeg, :NonPos, :SOC, :SDP, :Exp
 
 function getconicdual(m::SCSMathProgModel)
     dual = m.dual_sol[m.row_map_ind]
+    # flip sign for NonPos since it's treated as NonNeg by SCS
+    for i in 1:length(m.row_map_type)
+        if m.row_map_type[i] == :NonPos
+            dual[i] = -dual[i]
+        end
+    end
     # undo the rescaling of the SDP variables
     if !((:rescale, false) in m.options)
         rescaleconicdual!(m, dual)


### PR DESCRIPTION
Now output in https://github.com/JuliaOpt/SCS.jl/issues/40 is:

```
julia> @show MathProgBase.status(m)
MathProgBase.status(m) = :Optimal
:Optimal

julia> @show MathProgBase.getobjval(m)
MathProgBase.getobjval(m) = -0.0005944812927751632
-0.0005944812927751632

julia> @show MathProgBase.getsolution(m)
MathProgBase.getsolution(m) = [-0.0005944812927751632,1.0000244304176664,1.000024520748117]
3-element Array{Float64,1}:
 -0.000594481
  1.00002    
  1.00002    

julia> y = MathProgBase.getconicdual(m)
5-element Array{Float64,1}:
  1663.68
  1663.68
  1663.68
     1.0 
 -1663.68

julia> @show y
y = [1663.6755938289195,1663.676176978334,1663.6760356732946,1.0000001698583723,-1663.675735133884]
5-element Array{Float64,1}:
  1663.68
  1663.68
  1663.68
     1.0 
 -1663.68

julia> @show -dot(b,y) # should match primal objective
-(dot(b,y)) = -0.0005831494145240868
-0.0005831494145240868

julia> @show c + A'y # should be all zeros, since variables are free
c + A' * y = [-1.698583722564706e-7,0.00014130496447251062,0.00014130503950582352]
3-element Array{Float64,1}:
 -1.69858e-7 
  0.000141305
  0.000141305
```