### PR TITLE
don't mix blas integer size and binary word size

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -49,10 +49,9 @@ if blasvendor == :openblas64
 end
 if blasvendor == :mkl
     if Base.USE_BLAS64
-        cflags = "$cflags -DMKL_ILP64 -m64 -DBLAS64"
+        cflags = "$cflags -DMKL_ILP64 -DBLAS64"
         ldflags = "$ldflags -lmkl_intel_ilp64"
     else
-        cflags = "$cflags -m32"
         ldflags = "$ldflags -lmkl_intel"
     end
     cflags = "$cflags -fopenmp"


### PR DESCRIPTION
`-m32` and `-m64` are for getting different architecture binaries from a multilib compiler
Julia can use either 32 or 64 bit integers in blas on 64 bit, these aren't coupled