### PR TITLE
fix broken warning

### DIFF
--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -16,8 +16,8 @@ function __init__()
     if is_unix()
         dlopen(Base.liblapack_name, RTLD_LAZY|RTLD_DEEPBIND|RTLD_GLOBAL)
     end
+    depsdir = realpath(joinpath(dirname(@__FILE__),"..","deps"))
     if !(vnum.major == 1 && vnum.minor in [1,2])
-        depsdir = realpath(joinpath(dirname(@__FILE__),"..","deps"))
         error("Current SCS version installed is $(SCS_version()), but we require version 1.1.* or 1.2.*. On Linux and Windows, delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"SCS\"). On OS X, run `using Homebrew; Homebrew.update()` in Julia.")
     end
     if is_linux() && vnum.major == 1 && vnum.minor == 1


### PR DESCRIPTION
All Linux installs with SCS 1.1 are broken as of the last release:
```
julia> using SCS
ERROR: InitError: UndefVarError: depsdir not defined
 in __init__() at /home/mlubin/.julia/v0.5/SCS/src/SCS.jl:24
 in _include_from_serialized(::String) at ./loading.jl:150
 in _require_from_serialized(::Int64, ::Symbol, ::String, ::Bool) at ./loading.jl:187
 in _require_search_from_serialized(::Int64, ::Symbol, ::String, ::Bool) at ./loading.jl:217
 in require(::Symbol) at ./loading.jl:371
during initialization of module SCS
```
@kalmarek, please test changes like this.