### PR TITLE
Update interface for SCS 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rho_x                   # x equality constraint scaling: 1e-3 (default)
 cg_rate                 # for indirect, tolerance goes down like (1/iter)^cg_rate: 2 (default)
 verbose                 # boolean, write out progress: 1 (default)
 normalize               # boolean, heuristic data rescaling: 1 (default)
-scale                   # if normalized, rescales by this factor: 5 (default)
+scale                   # if normalized, rescales by this factor: 1 (default)
 warm_start              # boolean, warm start (put initial guess in Sol struct): 0 (default)
 acceleration_lookback   # int, acceleration memory parameter: 20 (default)
 ```

--- a/README.md
+++ b/README.md
@@ -33,15 +33,16 @@ SCS implements the solver-independent [MathProgBase](https://github.com/JuliaOpt
 All SCS solver options can be set through the direct interface(documented below) and through MathProgBase.
 The list of options is defined the [`scs.h` header](https://github.com/cvxgrp/scs/blob/0f9f51d663efd75b9d55d9f6524da75baa498aee/include/scs.h#L30), which we reproduce here:
 ```
-max_iters       # maximum iterations to take: 2500 (default)
-eps             # convergence tolerance: 1e-3 (default)
-alpha           # relaxation parameter: 1.8 (default)
-rho_x           # x equality constraint scaling: 1e-3 (default)
-cg_rate         # for indirect, tolerance goes down like (1/iter)^cg_rate: 2 (default)
-verbose         # boolean, write out progress: 1 (default)
-normalize       # boolean, heuristic data rescaling: 1 (default)
-scale           # if normalized, rescales by this factor: 5 (default)
-warm_start      # boolean, warm start (put initial guess in Sol struct): 0 (default)
+max_iters               # maximum iterations to take: 2500 (default)
+eps                     # convergence tolerance: 1e-3 (default)
+alpha                   # relaxation parameter: 1.8 (default)
+rho_x                   # x equality constraint scaling: 1e-3 (default)
+cg_rate                 # for indirect, tolerance goes down like (1/iter)^cg_rate: 2 (default)
+verbose                 # boolean, write out progress: 1 (default)
+normalize               # boolean, heuristic data rescaling: 1 (default)
+scale                   # if normalized, rescales by this factor: 5 (default)
+warm_start              # boolean, warm start (put initial guess in Sol struct): 0 (default)
+acceleration_lookback   # int, acceleration memory parameter: 20 (default)
 ```
 To use these settings you can either pass them as keyword arguments to `SCS_solve` (high level interface) or as arguments to the `SCSSolver` constructor (MathProgBase interface), e.g.
 ```julia

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -25,10 +25,10 @@ provides(Sources, URI("https://github.com/cvxgrp/scs/archive/v$version.tar.gz"),
     [scs], os=:Unix, unpacked_dir="scs-$version")
 
 # Windows binaries built in Cygwin as follows:
-# CFLAGS="-DLONG -DCOPYAMATRIX -DUSE_LAPACK -DCTRLC=1 -DBLAS64 -DBLASSUFFIX=_64_" LDFLAGS="-L$HOME/julia/usr/bin -lopenblas64_" make CC=x86_64-w64-mingw32-gcc out/libscsdir.dll
+# CFLAGS="-DDLONG -DCOPYAMATRIX -DUSE_LAPACK -DCTRLC=1 -DBLAS64 -DBLASSUFFIX=_64_" LDFLAGS="-L$HOME/julia/usr/bin -lopenblas64_" make CC=x86_64-w64-mingw32-gcc out/libscsdir.dll
 # mv out bin64
 # make clean
-# CFLAGS="-DLONG -DCOPYAMATRIX -DUSE_LAPACK -DCTRLC=1" LDFLAGS="-L$HOME/julia32/usr/bin -lopenblas" make CC=i686-w64-mingw32-gcc out/libscsdir.dll
+# CFLAGS="-DDLONG -DCOPYAMATRIX -DUSE_LAPACK -DCTRLC=1" LDFLAGS="-L$HOME/julia32/usr/bin -lopenblas" make CC=i686-w64-mingw32-gcc out/libscsdir.dll
 # mv out bin32
 provides(Binaries, URI("https://cache.julialang.org/https://bintray.com/artifact/download/tkelman/generic/scs-$win_version-r2.7z"),
     [scs], unpacked_dir="bin$(Sys.WORD_SIZE)", os = :Windows,
@@ -43,7 +43,7 @@ ldflags = ""
 if is_apple()
     ldflags = "$ldflags -undefined suppress -flat_namespace"
 end
-cflags = "-DCOPYAMATRIX -DLONG -DUSE_LAPACK -DCTRLC=1"
+cflags = "-DCOPYAMATRIX -DDLONG -DUSE_LAPACK -DCTRLC=1"
 if blasvendor == :openblas64
     cflags = "$cflags -DBLAS64 -DBLASSUFFIX=_64_"
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -25,10 +25,10 @@ provides(Sources, URI("https://github.com/cvxgrp/scs/archive/v$version.tar.gz"),
     [scs], os=:Unix, unpacked_dir="scs-$version")
 
 # Windows binaries built in Cygwin as follows:
-# CFLAGS="-DDLONG -DCOPYAMATRIX -DLAPACK_LIB_FOUND -DCTRLC=1 -DBLAS64 -DBLASSUFFIX=_64_" LDFLAGS="-L$HOME/julia/usr/bin -lopenblas64_" make CC=x86_64-w64-mingw32-gcc out/libscsdir.dll
+# CFLAGS="-DLONG -DCOPYAMATRIX -DUSE_LAPACK -DCTRLC=1 -DBLAS64 -DBLASSUFFIX=_64_" LDFLAGS="-L$HOME/julia/usr/bin -lopenblas64_" make CC=x86_64-w64-mingw32-gcc out/libscsdir.dll
 # mv out bin64
 # make clean
-# CFLAGS="-DDLONG -DCOPYAMATRIX -DLAPACK_LIB_FOUND -DCTRLC=1" LDFLAGS="-L$HOME/julia32/usr/bin -lopenblas" make CC=i686-w64-mingw32-gcc out/libscsdir.dll
+# CFLAGS="-DLONG -DCOPYAMATRIX -DUSE_LAPACK -DCTRLC=1" LDFLAGS="-L$HOME/julia32/usr/bin -lopenblas" make CC=i686-w64-mingw32-gcc out/libscsdir.dll
 # mv out bin32
 provides(Binaries, URI("https://cache.julialang.org/https://bintray.com/artifact/download/tkelman/generic/scs-$win_version-r2.7z"),
     [scs], unpacked_dir="bin$(Sys.WORD_SIZE)", os = :Windows,
@@ -43,7 +43,7 @@ ldflags = ""
 if is_apple()
     ldflags = "$ldflags -undefined suppress -flat_namespace"
 end
-cflags = "-DCOPYAMATRIX -DDLONG -DLAPACK_LIB_FOUND -DCTRLC=1"
+cflags = "-DCOPYAMATRIX -DLONG -DUSE_LAPACK -DCTRLC=1"
 if blasvendor == :openblas64
     cflags = "$cflags -DBLAS64 -DBLASSUFFIX=_64_"
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,8 +18,8 @@ if is_apple()
     provides(Homebrew.HB, "scs", scs, os = :Darwin)
 end
 
-version = "1.2.6"
-win_version = "1.1.5"
+version = "2.0.0"
+win_version = "2.0.0"
 
 provides(Sources, URI("https://github.com/cvxgrp/scs/archive/v$version.tar.gz"),
     [scs], os=:Unix, unpacked_dir="scs-$version")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,7 +68,7 @@ provides(SimpleBuild,
         CreateDirectory(joinpath(prefix, "lib"))
         FileRule(joinpath(prefix, "lib", libname), @build_steps begin
             ChangeDirectory(srcdir)
-            setenv(`make out/$libname`, ENV2)
+            setenv(`make BLASLDFLAGS="" `out/$libname`, ENV2)
             `mv out/$libname $prefix/lib`
         end)
     end), [scs], os=:Unix)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,7 +68,7 @@ provides(SimpleBuild,
         CreateDirectory(joinpath(prefix, "lib"))
         FileRule(joinpath(prefix, "lib", libname), @build_steps begin
             ChangeDirectory(srcdir)
-            setenv(`make BLASLDFLAGS="" `out/$libname`, ENV2)
+            setenv(`make BLASLDFLAGS= `out/$libname`, ENV2)
             `mv out/$libname $prefix/lib`
         end)
     end), [scs], os=:Unix)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,7 +68,7 @@ provides(SimpleBuild,
         CreateDirectory(joinpath(prefix, "lib"))
         FileRule(joinpath(prefix, "lib", libname), @build_steps begin
             ChangeDirectory(srcdir)
-            setenv(`make BLASLDFLAGS= `out/$libname`, ENV2)
+            setenv(`make BLASLDFLAGS= out/$libname`, ENV2)
             `mv out/$libname $prefix/lib`
         end)
     end), [scs], os=:Unix)

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -17,11 +17,8 @@ function __init__()
         dlopen(Base.liblapack_name, RTLD_LAZY|RTLD_DEEPBIND|RTLD_GLOBAL)
     end
     depsdir = realpath(joinpath(dirname(@__FILE__),"..","deps"))
-    if !(vnum.major == 1 && vnum.minor in [1,2])
-        error("Current SCS version installed is $(SCS_version()), but we require version 1.1.* or 1.2.*. On Linux and Windows, delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"SCS\"). On OS X, run `using Homebrew; Homebrew.update()` in Julia.")
-    end
-    if is_linux() && vnum.major == 1 && vnum.minor == 1
-        warn("Current SCS version installed is $(SCS_version()), but a newer version (1.2.*) is available. To upgrade, delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"SCS\").")
+    if vnum.major == 1
+        error("Current SCS version installed is $(SCS_version()), but we require version 2.*. On Linux and Windows, delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"SCS\"). On OS X, run `using Homebrew; Homebrew.update()` in Julia.")
     end
 end
 

--- a/src/high_level_wrapper.jl
+++ b/src/high_level_wrapper.jl
@@ -13,9 +13,9 @@ function create_scs_matrix(m::Int, n::Int, A::SCSVecOrMatOrSparse)
 end
 
 function create_scs_settings(normalize=1::Int, scale=converter(Cdouble, 5.0)::Cdouble, rho_x=convert(Cdouble,1e-3)::Cdouble,
-                        max_iters=2500::Int, eps=converter(Cdouble, 1e-3)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
-                        cg_rate=convert(Cdouble,2)::Cdouble, verbose=1::Int, warm_start=0::Int)
-    return SCSSettings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start)
+                        max_iters=5000::Int, eps=converter(Cdouble, 1e-5)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
+                        cg_rate=convert(Cdouble,2)::Cdouble, verbose=1::Int, warm_start=0::Int, acceleration_lookback=20::Int)
+    return SCSSettings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback)
 end
 
 # Create an SCSData type
@@ -28,16 +28,16 @@ end
 # c is of length n x 1
 # refer to create_scs_cone for K
 function create_scs_data(;m::Int=nothing, n::Int=nothing, A::Ptr{SCSMatrix}=nothing,
-        b::Ptr{Cdouble}=nothing,  c::Ptr{Cdouble}=nothing, max_iters=20000::Int,
-        eps=convert(Cdouble, 1e-4)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
+        b::Ptr{Cdouble}=nothing,  c::Ptr{Cdouble}=nothing, max_iters=5000::Int,
+        eps=convert(Cdouble, 1e-5)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
         rho_x=convert(Cdouble, 1e-3)::Cdouble, scale=convert(Cdouble, 5.0)::Cdouble,
         cg_rate=convert(Cdouble, 2)::Cdouble, verbose=1::Int,
-        normalize=1::Int, warm_start=0::Int, options...)
+        normalize=1::Int, warm_start=0::Int, acceleration_lookback=20::Int, options...)
 
     for (k, v) in options
         @eval(($k) = ($v))
     end
-    stgs = create_scs_settings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start)
+    stgs = create_scs_settings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback)
     return SCSData(m, n, A, b, c, pointer([stgs]))
 end
 

--- a/src/high_level_wrapper.jl
+++ b/src/high_level_wrapper.jl
@@ -12,7 +12,7 @@ function create_scs_matrix(m::Int, n::Int, A::SCSVecOrMatOrSparse)
     return SCSMatrix(pointer(values), pointer(rowval), pointer(colptr), m, n)
 end
 
-function create_scs_settings(normalize=1::Int, scale=converter(Cdouble, 5.0)::Cdouble, rho_x=convert(Cdouble,1e-3)::Cdouble,
+function create_scs_settings(normalize=1::Int, scale=converter(Cdouble, 1.0)::Cdouble, rho_x=convert(Cdouble,1e-3)::Cdouble,
                         max_iters=5000::Int, eps=converter(Cdouble, 1e-5)::Cdouble, alpha=convert(Cdouble, 1.8)::Cdouble,
                         cg_rate=convert(Cdouble,2)::Cdouble, verbose=1::Int, warm_start=0::Int, acceleration_lookback=20::Int)
     return SCSSettings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback)

--- a/src/types.jl
+++ b/src/types.jl
@@ -23,6 +23,7 @@ immutable SCSSettings
     cg_rate::Cdouble # for indirect, tolerance goes down like (1/iter)^cg_rate: 2
     verbose::Int # boolean, write out progress: 1
     warm_start::Int # boolean, warm start (put initial guess in Sol struct): 0
+    acceleration_lookback::Int # boolean, acceleration memory parameter: 20
 end
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,7 +15,7 @@ end
 
 immutable SCSSettings
     normalize::Int # boolean, heuristic data rescaling: 1
-    scale::Cdouble # if normalized, rescales by this factor: 5
+    scale::Cdouble # if normalized, rescales by this factor: 1
     rho_x::Cdouble # x equality constraint scaling: 1e-3
     max_iters::Int # maximum iterations to take: 2500
     eps::Cdouble # convergence tolerance: 1e-3


### PR DESCRIPTION
SCS 2.0 makes several changes, but the main one that interfaces need to be aware of is the addition of a new field in the settings called `acceleration_lookback` which is the number of iterates that SCS will keep in memory in order to do an acceleration extrapolation step. Due to the acceleration step SCS 2.0 is in general faster than SCS 1.*, and consequently has tightened the default tolerance from 1e-3 to 1e-5.

Merging this will require re-uploading new binaries for all platforms, if I understand the distribution process correctly.