### PR TITLE
Enh/options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ solution = SCS_solve(m, n, A, ..., psize; max_iters=10, verbose=0);
 m = solve!(problem, SCSSolver(max_iters=10, verbose=0))
 ```
 
-Moreover, You may select one of the linear solvers to be used by `SCSSolver` via `linearsolver` keyword. The options available are `SCS.Indirect` (the default) and `SCS.Direct`.
+Moreover, You may select one of the linear solvers to be used by `SCSSolver` via `linear_solver` keyword. The options available are `SCS.Indirect` (the default) and `SCS.Direct`.
 
 ### High level wrapper
 

--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -98,9 +98,9 @@ function optimize!(m::SCSMathProgModel)
     T = SCS.Indirect # the default method
     options = m.options
     opts = Dict(m.options)
-    if :linearsolver in keys(opts)
-        T = opts[:linearsolver]
-        options = [(k,v) for (k,v) in options if k !=:linearsolver]
+    if :linear_solver in keys(opts)
+        T = opts[:linear_solver]
+        options = [(k,v) for (k,v) in options if k !=:linear_solver]
     end
 
     solution = SCS_solve(T, m.m, m.n, m.A, m.b, m.c, m.f, m.l, m.q,

--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -96,12 +96,11 @@ function optimize!(m::SCSMathProgModel)
     t = time()
 
     T = SCS.Indirect # the default method
-    options = m.options
     opts = Dict(m.options)
     if :linear_solver in keys(opts)
         T = opts[:linear_solver]
-        options = [(k,v) for (k,v) in options if k !=:linear_solver]
     end
+    options = [(k,v) for (k,v) in m.options if k !=:linear_solver]
 
     solution = SCS_solve(T, m.m, m.n, m.A, m.b, m.c, m.f, m.l, m.q,
                          m.s, m.ep, m.ed, Float64[],

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -58,6 +58,11 @@ function SCS_solve(T::Union{Type{Direct}, Type{Indirect}},
         k in all_kwargs || throw(ArgumentError("Unknown keyword passed to SCS solver: $k"))
     end
 
+    for param in keys(opts)
+        # when dropping support for 0.6 could be replaced with setproperty!
+        setfield!(settings[], param, convert(fieldtype(SCSSettings, param), opts[param]))
+    end
+
     cone = Ref(SCSCone(f, l, q, s, ep, ed, p))
     info = Ref(SCSInfo())
 

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -51,6 +51,13 @@ function SCS_solve(T::Union{Type{Direct}, Type{Indirect}},
     data = Ref(SCSData(m, n, Base.unsafe_convert(Ptr{SCSMatrix}, matrix), pointer(b), pointer(c), Base.unsafe_convert(Ptr{SCSSettings},settings)))
     SCS_set_default_settings!(T, data)
 
+    opts = Dict(options)
+
+    all_kwargs = [:scale, :rho_x, :max_iters, :eps, :alpha, :cg_rate, :acceleration_lookback, :normalize, :verbose, :warm_start]
+    for k in keys(opts)
+        k in all_kwargs || throw(ArgumentError("Unknown keyword passed to SCS solver: $k"))
+    end
+
     cone = Ref(SCSCone(f, l, q, s, ep, ed, p))
     info = Ref(SCSInfo())
 

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -47,8 +47,10 @@ function SCS_solve(T::Union{Type{Direct}, Type{Indirect}},
 
     managed_matrix = ManagedSCSMatrix(m, n, A)
     matrix = Ref(SCSMatrix(managed_matrix))
-    settings = Ref(SCSSettings(;options...))
+    settings = Ref(SCSSettings())
     data = Ref(SCSData(m, n, Base.unsafe_convert(Ptr{SCSMatrix}, matrix), pointer(b), pointer(c), Base.unsafe_convert(Ptr{SCSSettings},settings)))
+    SCS_set_default_settings!(T, data)
+
     cone = Ref(SCSCone(f, l, q, s, ep, ed, p))
     info = Ref(SCSInfo())
 
@@ -86,6 +88,11 @@ end
 # Take Ref{}s because SCS might modify the structs
 for (T, lib) in zip([SCS.Direct, SCS.Indirect], [SCS.direct, SCS.indirect])
     @eval begin
+
+        function SCS_set_default_settings!(::Type{$T}, data::Ref{SCSData})
+            ccall((:scs_set_default_settings, $lib), Nothing, (Ref{SCSData}, ), data)
+        end
+
         function SCS_init(::Type{$T}, data::Ref{SCSData}, cone::Ref{SCSCone}, info::Ref{SCSInfo})
 
             p_work = ccall((:scs_init, $lib), Ptr{Nothing},

--- a/src/types.jl
+++ b/src/types.jl
@@ -37,7 +37,7 @@ SCSMatrix(m::ManagedSCSMatrix) =
     SCSMatrix(pointer(m.values), pointer(m.rowval), pointer(m.colptr), m.m, m.n)
 
 
-struct SCSSettings
+mutable struct SCSSettings
     normalize::Int # boolean, heuristic data rescaling: 1
     scale::Cdouble # if normalized, rescales by this factor: 1
     rho_x::Cdouble # x equality constraint scaling: 1e-3
@@ -48,12 +48,9 @@ struct SCSSettings
     verbose::Int # boolean, write out progress: 1
     warm_start::Int # boolean, warm start (put initial guess in Sol struct): 0
     acceleration_lookback::Int # acceleration memory parameter: 20
-end
 
-function SCSSettings(;normalize=1::Int, scale=convert(Cdouble, 1.0)::Cdouble, rho_x=convert(Cdouble,1e-3)::Cdouble,
-                        max_iters=5000::Int, eps=convert(Cdouble, 1e-5)::Cdouble, alpha=convert(Cdouble, 1.5)::Cdouble,
-                        cg_rate=convert(Cdouble,2)::Cdouble, verbose=1::Int, warm_start=0::Int, acceleration_lookback=20::Int)
-    return SCSSettings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback)
+    SCSSettings() = new()
+    SCSSettings(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback) = new(normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback)
 end
 
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -20,20 +20,22 @@ s = SCSSolver()
 m = MathProgBase.ConicModel(s)
 MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
 MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-3)
 
-# With eps = 1e-8, solution should be far more accurate
-s = SCSSolver(eps=1e-8)
+@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-6, rtol=0.0)
+@test !isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-7, rtol=0.0)
+
+# With eps = 1e-12, solution should be far more accurate
+s = SCSSolver(eps=1e-12)
 m = MathProgBase.ConicModel(s)
 MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
 MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-5)
+@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-10, rtol=0.0)
 
 # With a warmstart from the eps = 1e-8 solution, solution should be extremely accurate even after 1 iteration
 SCS.addoption!(m, :warm_start, true)
 SCS.addoption!(m, :max_iters, 1)
 MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-5)
+@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-10, rtol=0.0)
 
 # Now let's do the same warmstart, but on a new instance of the same problem
 primal_sol = m.primal_sol
@@ -44,4 +46,4 @@ m = MathProgBase.ConicModel(s)
 MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
 MathProgBase.setwarmstart!(m, primal_sol; dual_sol = dual_sol, slack = slack)
 MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-5)
+@test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-10, rtol=0.0)


### PR DESCRIPTION
Would be great if someone could test it on the MOI side;

I took a simple route of extracting the `Direct`/`Indirect` type from `options` in `optimize!` (as it was done in MPB), but that could be easily changed to `Optimizer` (and `SCSMathProgModel`) parametrized by the type