### PR TITLE
Add using Compat in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Compat
 using Compat.Test
 using SCS
 


### PR DESCRIPTION
Otherwise, the tests fails at `https://github.com/JuliaOpt/MathOptInterface.jl/blob/00b5965ea1491a893af01c0bf8b5501a0f11c4bb/src/Utilities/model.jl#L550` with MOI v0.6.2 because `Nothing` is not defined on Julia v0.6.
See https://juliarun-ci.s3.amazonaws.com/a8e4d0c3b1d78372dcdb95f9a6b6c484bf33a851/SCS_with_pull_request_of_MathOptInterface_on_julia_0_6.log