### PR TITLE
✅ Enable solve_blank_obj fixed in MOI v0.6.2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6.2
 MathProgBase 0.5 0.8
-MathOptInterface 0.6 0.7
+MathOptInterface 0.6.2 0.7
 BinaryProvider 0.3
 Compat 0.47

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -20,19 +20,7 @@ for T in [SCS.Direct, SCS.Indirect]
     config = MOIT.TestConfig(atol=1e-5)
 
     @testset "Unit" begin
-        MOIT.unittest(MOIB.SplitInterval{Float64}(optimizer),
-                      # solve_blank_obj needs 1e-2 tolerance
-                      MOIT.TestConfig(atol=1e-2, rtol=1e-2),
-                      [# Quadratic functions are not supported
-                       "solve_qcp_edge_cases", "solve_qp_edge_cases",
-                       # Integer and ZeroOne sets are not supported
-                       "solve_integer_edge_cases", "solve_objbound_edge_cases"])
-    end
-
-    @testset "Continuous linear problems" begin
-        MOIT.unittest(MOIB.SplitInterval{Float64}(optimizer),
-                      # solve_blank_obj needs 1e-2 tolerance
-                      MOIT.TestConfig(atol=1e-2, rtol=1e-2),
+        MOIT.unittest(MOIB.SplitInterval{Float64}(optimizer), config,
                       [# Quadratic functions are not supported
                        "solve_qcp_edge_cases", "solve_qp_edge_cases",
                        # Integer and ZeroOne sets are not supported


### PR DESCRIPTION
It was resolved in https://github.com/JuliaOpt/MathOptInterface.jl/pull/537