### PR TITLE
Fix/empty model

### DIFF
--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -45,6 +45,9 @@ function SCS_solve(T::Union{Type{Direct}, Type{Indirect}},
         slack::Vector{Float64}=Float64[];
         options...)
 
+    n > 0 || throw(ArgumentError("The number of variables in SCSModel must be greater than 0"))
+    m > 0 || throw(ArgumentError("The number of constraints in SCSModel must be greater than 0"))
+
     managed_matrix = ManagedSCSMatrix(m, n, A)
     matrix = Ref(SCSMatrix(managed_matrix))
     settings = Ref(SCSSettings(T; options...))

--- a/src/types.jl
+++ b/src/types.jl
@@ -183,7 +183,7 @@ end
 
 function sanatize_SCS_options(options)
     options = Dict(options)
-    if :linear_solver in keys(options)
+    if haskey(options, :linear_solver)
         linear_solver = options[:linear_solver]
         if linear_solver == Direct || linear_solver == Indirect
             nothing
@@ -195,7 +195,7 @@ function sanatize_SCS_options(options)
         linear_solver = Indirect # the default linear_solver
     end
 
-    SCS_options = fieldnames(SCSSettings)
+    SCS_options = append!([:linear_solver], fieldnames(SCSSettings))
     unrecognized = setdiff(keys(options), SCS_options)
     if length(unrecognized) > 0
         plur = length(unrecognized) > 1 ? "s" : ""

--- a/test/options.jl
+++ b/test/options.jl
@@ -61,7 +61,7 @@ catch ex
     ex
 end
 @test err.msg == "Unrecognized option passed to SCS: epps;
-Recognized options are: normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start and acceleration_lookback."
+Recognized options are: linear_solver, normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start and acceleration_lookback."
 
 # tests for incorrect options
 s = SCSSolver(linear_solver="AAA", eps=1e-12, epps=1.0)


### PR DESCRIPTION
fixes https://github.com/JuliaOpt/SCS.jl/issues/122
https://github.com/JuliaOpt/JuMP.jl/issues/1502

Two tests in `solve_blank_obj` fail (probably because we `throw`)

btw I noticed this:
```
julia> m = Model(); @variable(m, x <=1); m
Feasibility problem with:
 * 0 linear constraints
 * 1 variable
Solver is default solver

julia> m = Model(); x = @variable(m, x); @constraint(m, x <=1); m
Feasibility problem with:
 * 1 linear constraint
 * 1 variable
Solver is default solver
```
but I guess that it's fixed in MOI due to changes in models