### PR TITLE
Use verbose=0 for MPB and MOI tests

### DIFF
--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -15,7 +15,9 @@ MOIU.@model(SCSModelData,
             (MOI.VectorOfVariables,),
             (MOI.VectorAffineFunction,))
 for T in [SCS.Direct, SCS.Indirect]
-    optimizer = MOIU.CachingOptimizer(SCSModelData{Float64}(), SCS.Optimizer(linear_solver=T, eps=1e-8))
+    optimizer = MOIU.CachingOptimizer(SCSModelData{Float64}(),
+                                      SCS.Optimizer(linear_solver=T, eps=1e-8,
+                                                    verbose=0))
 
     config = MOIT.TestConfig(atol=1e-5)
 

--- a/test/MPBWrapper.jl
+++ b/test/MPBWrapper.jl
@@ -6,9 +6,13 @@ using Compat.Pkg: dir
 for T in [SCS.Direct, SCS.Indirect]
     @testset "MathProgBase $T" begin
         include(joinpath(dir("MathProgBase"),"test","conicinterface.jl"))
-        coniclineartest(SCS.SCSSolver(linear_solver=T, eps=1e-7), duals=true, tol=1e-5)
-        conicSOCtest(SCS.SCSSolver(linear_solver=T), duals=true, tol=1e-5)
-        conicEXPtest(SCS.SCSSolver(linear_solver=T), duals=true, tol=1e-5)
-        conicSDPtest(SCS.SCSSolver(linear_solver=T, eps=1e-7), duals=true, tol=1e-5)
+        coniclineartest(SCS.SCSSolver(linear_solver=T, eps=1e-7, verbose=0),
+                        duals=true, tol=1e-5)
+        conicSOCtest(SCS.SCSSolver(linear_solver=T, verbose=0),
+                     duals=true, tol=1e-5)
+        conicEXPtest(SCS.SCSSolver(linear_solver=T, verbose=0),
+                     duals=true, tol=1e-5)
+        conicSDPtest(SCS.SCSSolver(linear_solver=T, eps=1e-7, verbose=0),
+                     duals=true, tol=1e-5)
     end
 end


### PR DESCRIPTION
When there are failures in the tests, they get drowned by the SCS log.