### PR TITLE
Fix method ambiguity of MOIU.load_constraint

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -276,7 +276,7 @@ orderidx(idx, s) = idx
 function orderidx(idx, s::MOI.PositiveSemidefiniteConeTriangle)
     sympackedUtoLidx(idx, s.side_dimension)
 end
-function MOIU.load_constraint(optimizer::Optimizer, ci, f::MOI.VectorAffineFunction, s::MOI.AbstractVectorSet)
+function MOIU.load_constraint(optimizer::Optimizer, ci::MOI.ConstraintIndex, f::MOI.VectorAffineFunction, s::MOI.AbstractVectorSet)
     A = sparse(output_index.(f.terms), variable_index_value.(f.terms), coefficient.(f.terms))
     # sparse combines duplicates with + but does not remove zeros created so we call dropzeros!
     dropzeros!(A)


### PR DESCRIPTION
While running against JuMP examples on https://github.com/JuliaOpt/JuMP.jl/pull/2003 , the following error appeared and tests successfully with this PR.

```julia
robust_uncertainty.jl: Error During Test at /home/coroa/.julia/dev/JuMP/examples/run_examples.jl:20
  Got exception outside of a @test
  LoadError: MethodError: load_constraint(::SCS.Optimizer, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.SecondOrderCone}, ::MathOptInterface.VectorAffineFunction{Float64}, ::MathOptInterface.SecondOrderCone) is ambiguous. Candidates:
    load_constraint(optimizer::SCS.Optimizer, ci, f::MathOptInterface.VectorAffineFunction, s::MathOptInterface.AbstractVectorSet) in SCS at /home/coroa/.julia/packages/SCS/RkVe4/src/MOI_wrapper.jl:280
    load_constraint(model::MathOptInterface.ModelLike, ::MathOptInterface.ConstraintIndex, func::MathOptInterface.AbstractFunction, set::MathOptInterface.AbstractSet) in MathOptInterface.Utilities at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/copy.jl:310
  Possible fix, define
    load_constraint(::SCS.Optimizer, ::MathOptInterface.ConstraintIndex, ::MathOptInterface.VectorAffineFunction, ::MathOptInterface.AbstractVectorSet)
  Stacktrace:
   [1] load_constraints(::SCS.Optimizer, ::MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}, ::Bool, ::MathOptInterface.Utilities.IndexMap, ::Type{MathOptInterface.VectorAffineFunction{Float64}}, ::Type{MathOptInterface.SecondOrderCone}) at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/copy.jl:337
   [2] allocate_load(::SCS.Optimizer, ::MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}, ::Bool) at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/copy.jl:387
   [3] #automatic_copy_to#88 at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/copy.jl:17 [inlined]
   [4] #automatic_copy_to at ./none:0 [inlined]
   [5] #copy_to#29 at /home/coroa/.julia/packages/SCS/RkVe4/src/MOI_wrapper.jl:126 [inlined]
   [6] #copy_to at ./none:0 [inlined]
   [7] attach_optimizer(::MathOptInterface.Utilities.CachingOptimizer{SCS.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}) at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/cachingoptimizer.jl:130
   [8] optimize!(::MathOptInterface.Utilities.CachingOptimizer{SCS.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}) at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/cachingoptimizer.jl:166
   [9] optimize!(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{SCS.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}}) at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Bridges/bridge_optimizer.jl:71
   [10] optimize!(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}) at /home/coroa/.julia/packages/MathOptInterface/btEL4/src/Utilities/cachingoptimizer.jl:170
   [11] #optimize!#78(::Bool, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(optimize!), ::Model, ::Nothing) at /home/coroa/.julia/packages/JuMP/j37K8/src/optimizer_interface.jl:141
   [12] optimize! at /home/coroa/.julia/packages/JuMP/j37K8/src/optimizer_interface.jl:111 [inlined] (repeats 2 times)
   [13] example_robust_uncertainty() at /home/coroa/.julia/dev/JuMP/examples/robust_uncertainty.jl:46
   [14] top-level scope at /home/coroa/.julia/dev/JuMP/examples/robust_uncertainty.jl:53
   [15] include at ./boot.jl:328 [inlined]
   [16] include_relative(::Module, ::String) at ./loading.jl:1094
   [17] include(::Module, ::String) at ./Base.jl:31
   [18] include(::String) at ./client.jl:431
   [19] top-level scope at /home/coroa/.julia/dev/JuMP/examples/run_examples.jl:21
   [20] top-level scope at /home/coroa/src/juliav1.2/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1186
   [21] top-level scope at /home/coroa/.julia/dev/JuMP/examples/run_examples.jl:20
   [22] top-level scope at /home/coroa/src/juliav1.2/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
   [23] top-level scope at /home/coroa/.julia/dev/JuMP/examples/run_examples.jl:20
   [24] include at ./boot.jl:328 [inlined]
   [25] include_relative(::Module, ::String) at ./loading.jl:1094
   [26] include(::Module, ::String) at ./Base.jl:31
   [27] exec_options(::Base.JLOptions) at ./client.jl:295
   [28] _start() at ./client.jl:464
  in expression starting at /home/coroa/.julia/dev/JuMP/examples/robust_uncertainty.jl:53
```