### PR TITLE
Allow CI failure with Julia 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ julia:
   - 1.0
   - 1.1
   - 1.2
+matrix:
+  allow_failures:
+    - julia: 1.2
 notifications:
   email: false
 after_success:


### PR DESCRIPTION
We can still see the outcome, but GitHub does not consider it a failed test.
I think this makes sense, since Julia 1.2 is not released yet?