### PR TITLE
Fix support constraint for DualExponentialCone

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -117,7 +117,8 @@ function MOI.supports_constraint(
     ::Optimizer,
     ::Type{<:MOI.VectorAffineFunction{Float64}},
     ::Type{<:Union{MOI.Zeros, MOI.Nonnegatives, MOI.SecondOrderCone,
-                   MOI.ExponentialCone, MOI.PositiveSemidefiniteConeTriangle,
+                   MOI.ExponentialCone, MOI.DualExponentialCone, 
+                   MOI.PositiveSemidefiniteConeTriangle,
                    MOI.PowerCone, MOI.DualPowerCone}})
     return true
 end


### PR DESCRIPTION
Forgot to add to the `support_constraint` function, it is probably better to wait for MOI to have the tests for DualExponentialCone https://github.com/JuliaOpt/MathOptInterface.jl/pull/873.