### PR TITLE
expose the number of iterations as an MOI attribute

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -48,6 +48,11 @@ for T in [SCS.Direct, SCS.Indirect]
         MOIT.contlineartest(bridged, config)
     end
 
+    @testset "ADMMIterations attribute with $T" begin
+        MOIT.linear1test(bridged, config)
+        @test MOI.get(bridged, SCS.ADMMIterations()) > 0
+    end
+
     @testset "Continuous quadratic problems with $T" begin
         MOIT.qcptest(bridged, config)
     end


### PR DESCRIPTION
About naming the attribute: SCS does multiple kinds of iterations, e.g., ADMM iterations (main outer iterations) and CG iterations (inner iterations, in indirect mode only), so being specific seems reasonable. It's not obvious that this could or should be covered by a new MOI attribute, so I made it specific to SCS.