### PR TITLE
Fix performance bottleneck in _scalecoeff

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -260,9 +260,9 @@ end
 # coef: List of corresponding coefficients
 # d: dimension of set
 # rev: if true, we unscale instead (e.g. divide by √2 instead of multiply for PSD cone)
-function _scalecoef(rows::Union{UnitRange{Int64}, Vector{Int64}}, coef::Vector{Float64}, d::Int64, rev::Bool)
+function _scalecoef(rows::AbstractVector{<: Integer}, coef::Vector{<: AbstractFloat}, d::Integer, rev::Bool)
     scaling = rev ? 1 / √2 : 1 * √2
-    output = copy(coef)
+    output = deepcopy(coef)
     for i in 1:length(output)
         # See https://en.wikipedia.org/wiki/Triangular_number#Triangular_roots_and_tests_for_triangular_numbers
         val = 8 * rows[i] + 1

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -265,7 +265,8 @@ function _scalecoef(rows::Union{UnitRange{Int64}, Vector{Int64}}, coef::Vector{F
     output = copy(coef)
     for i in 1:length(output)
         # See https://en.wikipedia.org/wiki/Triangular_number#Triangular_roots_and_tests_for_triangular_numbers
-        is_diagonal_index = isinteger(sqrt(8*rows[i] + 1))
+        val = 8 * rows[i] + 1
+        is_diagonal_index = isqrt(val)^2 == val
         if !is_diagonal_index
             output[i] *= scaling
         end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -260,20 +260,19 @@ end
 # coef: List of corresponding coefficients
 # d: dimension of set
 # rev: if true, we unscale instead (e.g. divide by √2 instead of multiply for PSD cone)
-function _scalecoef(rows, coef, d, rev)
+function _scalecoef(rows::Union{UnitRange{Int64}, Vector{Int64}}, coef::Vector{Float64}, d::Int64, rev::Bool)
     scaling = rev ? 1 / √2 : 1 * √2
     output = copy(coef)
-    diagidx = BitSet()
-    for i in 1:d
-        push!(diagidx, trimap(i, i))
-    end
     for i in 1:length(output)
-        if !(rows[i] in diagidx)
+        # See https://en.wikipedia.org/wiki/Triangular_number#Triangular_roots_and_tests_for_triangular_numbers
+        is_diagonal_index = isinteger(sqrt(8*rows[i] + 1))
+        if !is_diagonal_index
             output[i] *= scaling
         end
     end
     return output
 end
+
 # Unscale the coefficients in `coef` with respective rows in `rows` for a set `s`
 scalecoef(rows, coef, s) = _scalecoef(rows, coef, MOI.dimension(s), false)
 # Unscale the coefficients in `coef` with respective rows in `rows` for a set of type `S` with dimension `d`

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -260,9 +260,9 @@ end
 # coef: List of corresponding coefficients
 # d: dimension of set
 # rev: if true, we unscale instead (e.g. divide by √2 instead of multiply for PSD cone)
-function _scalecoef(rows::AbstractVector{<: Integer}, coef::Vector{<: AbstractFloat}, d::Integer, rev::Bool)
+function _scalecoef(rows::AbstractVector{<: Integer}, coef::Vector{Float64}, d::Integer, rev::Bool)
     scaling = rev ? 1 / √2 : 1 * √2
-    output = deepcopy(coef)
+    output = copy(coef)
     for i in 1:length(output)
         # See https://en.wikipedia.org/wiki/Triangular_number#Triangular_roots_and_tests_for_triangular_numbers
         val = 8 * rows[i] + 1


### PR DESCRIPTION
I was trying to solve some SDPs with quite large `MOI.PositiveSemidefiniteConeTriangle` constraints and noticed that copying the problem into SCS format took unusually long (>5min).

I narrowed the problem down to the `_scalecoef` function:
https://github.com/JuliaOpt/SCS.jl/blob/bd8ef05828e434f17630442de9a812abf6ee7604/src/MOI_wrapper.jl#L263-L276

The way `diagidx` is assembled seems to cause performance problems. We fixed that issue in `COSMO`'s MOI-wrapper in the following way: 
https://github.com/oxfordcontrol/COSMO.jl/pull/87

I shamelessly copied @nrontsis fix. The fix reduces the time to assemble a large SDP to a few seconds.

You can use the following code to check this:
```julia
using MathOptInterface, SCS, Random, LinearAlgebra, SparseArrays, Random
const MOI = MathOptInterface
const MOIU = MOI.Utilities

MOIU.@model(InnerModel,
        (),
        (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
        (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone,
         MOI.PositiveSemidefiniteConeSquare, MOI.PositiveSemidefiniteConeTriangle, MOI.ExponentialCone, MOI.DualExponentialCone),
        (MOI.PowerCone, MOI.DualPowerCone),
        (),
        (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
        (MOI.VectorOfVariables,),
        (MOI.VectorAffineFunction,),);

rng = Random.MersenneTwister(21)

# create dummy data (likely infeasible, but not relevant here)
n = 800
m = 20
d = div(n * (n+1),2)
A = sprand(rng, d, m, 0.2)
b = rand(rng, d)
c = rand(rng,  m)

# create MOI model
model = MOIU.UniversalFallback(InnerModel{Float64}());
x = MOI.add_variables(model, m);

# define objective function:
objectiveFunction = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(c, x[1:m]), 0.0);
MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),objectiveFunction);
MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE);

# add PSD constraint
I, J, V = findnz(A)
terms = Vector{MOI.VectorAffineTerm{Float64}}(undef, length(I))
for k = 1:length(I)
  output_index = I[k]
  scalar_term = MOI.ScalarAffineTerm{Float64}(-V[k], x[J[k]])
  terms[k] = MOI.VectorAffineTerm{Float64}(output_index, scalar_term)
end
vaf = MOI.VectorAffineFunction{Float64}(terms, b)
psd_constraint = MOI.add_constraint(model, vaf, MOI.PositiveSemidefiniteConeTriangle(n));

optimizer = SCS.Optimizer()
CACHE = MOIU.UniversalFallback(MOIU.Model{Float64}())
cached = MOIU.CachingOptimizer(CACHE, optimizer)
MOI.copy_to(cached, model)
# this line takes >5min for old code and a few seconds with the proposed fix
MOI.optimize!(cached);
```



