### PR TITLE
Enh/refactor scs matrix usage

### DIFF
--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -55,15 +55,17 @@ function SCS_solve(T::Union{Type{Direct}, Type{Indirect}},
 
     solution = SCSSolution(pointer(primal_sol), pointer(dual_sol), pointer(slack))
 
+    settings = Base.cconvert(Ref{SCSSettings}, SCSSettings(T; options...))
     managed_matrix = ManagedSCSMatrix(m, n, A)
-    matrix = Ref(SCSMatrix(managed_matrix))
-    settings = Ref(SCSSettings(T; options...))
-    data = Ref(SCSData(m, n, Base.unsafe_convert(Ptr{SCSMatrix}, matrix), pointer(b), pointer(c), Base.unsafe_convert(Ptr{SCSSettings},settings)))
+    data = Base.cconvert(Ref{SCSData}, SCSData(m, n,
+        Base.unsafe_convert(Ref{SCSMatrix}, managed_matrix.scsmat), #creates Ptr{SCSMatrix}
+        pointer(b), pointer(c),
+        Base.unsafe_convert(Ref{SCSSettings}, settings))) #creates Ptr{SCSSettings}
+    # unsafe_convert doesn't protect from GC: mmatrix and settings must be GC.@preserved
+    cone = Base.cconvert(Ref{SCSCone}, SCSCone(f, l, q, s, ep, ed, p))
+    info = Base.cconvert(Ref{SCSInfo}, SCSInfo())
 
-    cone = Ref(SCSCone(f, l, q, s, ep, ed, p))
-    info = Ref(SCSInfo())
-
-    Base.GC.@preserve managed_matrix matrix settings b c q s p begin
+    Base.GC.@preserve managed_matrix settings b c q s p begin
         p_work = SCS_init(T, data, cone, info)
         status = SCS_solve(T, p_work, data, cone, solution, info)
         SCS_finish(T, p_work)
@@ -87,7 +89,7 @@ for (T, lib) in zip([SCS.Direct, SCS.Indirect], [SCS.direct, SCS.indirect])
         function SCS_init(::Type{$T}, data::Ref{SCSData}, cone::Ref{SCSCone}, info::Ref{SCSInfo})
 
             p_work = ccall((:scs_init, $lib), Ptr{Nothing},
-                (Ptr{SCSData}, Ptr{SCSCone}, Ptr{SCSInfo}),
+                (Ref{SCSData}, Ref{SCSCone}, Ref{SCSInfo}),
                 data, cone, info)
 
             return p_work
@@ -97,7 +99,7 @@ for (T, lib) in zip([SCS.Direct, SCS.Indirect], [SCS.direct, SCS.indirect])
         function SCS_solve(::Type{$T}, p_work::Ptr{Nothing}, data::Ref{SCSData}, cone::Ref{SCSCone}, solution::SCSSolution, info::Ref{SCSInfo})
 
             status = ccall((:scs_solve, $lib), Int,
-                (Ptr{Nothing}, Ptr{SCSData}, Ptr{SCSCone}, Ref{SCSSolution}, Ptr{SCSInfo}),
+                (Ptr{Nothing}, Ref{SCSData}, Ref{SCSCone}, Ref{SCSSolution}, Ref{SCSInfo}),
                 p_work, data, cone, solution, info)
 
             return status

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -58,10 +58,11 @@ function SCS_solve(T::Union{Type{Direct}, Type{Indirect}},
     settings = Base.cconvert(Ref{SCSSettings}, SCSSettings(T; options...))
     managed_matrix = ManagedSCSMatrix(m, n, A)
     data = Base.cconvert(Ref{SCSData}, SCSData(m, n,
-        Base.unsafe_convert(Ref{SCSMatrix}, managed_matrix.scsmat), #creates Ptr{SCSMatrix}
+        Base.unsafe_convert(Ref{SCSMatrix}, managed_matrix.scsmatref), # creates Ptr{SCSMatrix}
         pointer(b), pointer(c),
-        Base.unsafe_convert(Ref{SCSSettings}, settings))) #creates Ptr{SCSSettings}
-    # unsafe_convert doesn't protect from GC: mmatrix and settings must be GC.@preserved
+        Base.unsafe_convert(Ref{SCSSettings}, settings) # creates Ptr{SCSSettings}
+        ))
+    # unsafe_convert doesn't protect from GC: managed_matrix and settings must be GC.@preserved
     cone = Base.cconvert(Ref{SCSCone}, SCSCone(f, l, q, s, ep, ed, p))
     info = Base.cconvert(Ref{SCSInfo}, SCSInfo())
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,9 +35,9 @@ struct ManagedSCSMatrix
         # as long as the ManagedSCSMatrix is not GC collected.
         # One MUST
         #   `Base.unsafe_convert(Ref{SCSMatrix}, scsmatref)`
-        # when assignig to a field of type `Ptr{SCSMatrix}`, or specify
+        # when assigning to a field of type `Ptr{SCSMatrix}`, or specify
         #   `Ref{SCSMatrix}`
-        # in in the type tuple when ccalling with `scsmatref`
+        # in the type tuple when ccalling with `scsmatref`
 
         scsmatref = SCSMatrix(pointer(values), pointer(rowval), pointer(colptr), m, n)
 


### PR DESCRIPTION
according to the discussion https://discourse.julialang.org/t/how-to-keep-a-reference-for-c-structure-to-avoid-gc/9310/25 the way from `M::SCSMatrix` to `Ptr{SCSMatrix}` should be either
```julia
M_ref = Base.cconvert(Ref{SCSMatrix}, M) # Base.RefValue{SCSMatrix}
M_ptr = Base.unsafe_convert(Ref{SCSMatrix}, M_ref) # Ptr{SCSMatrix}, ready to go for ccall
```
or
```julia
M_ref = Base.cconvert(Ptr{SCSMatrix}, Ref(M)) # Base.RefValue{SCSMatrix}
M_ptr = Base.unsafe_convert(Ptr{SCSMatrix}, M_ref) # Ptr{SCSMatrix}
```
This is to align all of the calls / conversions in the code and do not use direct calls to `Ref` outside of `ccall`s.

Additionally (as explained in the comment in the code), `managed_matrix::ManagedSCSMatrix` stores `scsmatref`, a valid reference to its `SCSMatrix` counterpart, so that as long as `managed_matrix` lives, all pointers in `scsmatref` are guaranteed to be valid.