### PR TITLE
Scale off-diagonals of b before transforming U -> L

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -308,9 +308,8 @@ function MOIU.load_constraint(optimizer::Optimizer, ci::MOI.ConstraintIndex, f::
     i = offset .+ rows
     b = f.constants
     if s isa MOI.PositiveSemidefiniteConeTriangle
-        # FIXME shouldn't scale before ?
-        b = sympackedUtoL(b, s.side_dimension)
         b = scalecoef(rows, b, s)
+        b = sympackedUtoL(b, s.side_dimension)
         V = scalecoef(I, V, s)
         I = sympackedUtoLidx(I, s.side_dimension)
     end


### PR DESCRIPTION
As correctly noted in the `#FIXME comment` the scaling method `scale_coeff` assumes an upper triangular input (triangular numbers yield the diagonal entries of upper triangular elements of a matrix). Therefore, we have to keep the right order with scaling and transforming:

1. Scale, then transform U->L
2. Transform L->U, then unscale

I probably introduced that bug myself in #165. I noticed this when comparing the output of `JuMP + SCS` vs. `SCS.Direct`. I am not sure, why the unit tests didn't catch it.