### PR TITLE
Fix extraneous deprecation warning

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -73,7 +73,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         optimizer = new(ConeData(), false, nothing, MOISolution(), false,
                         Dict{Symbol, Any}())
         for (key, value) in kwargs
-            MOI.set(optimizer, MOI.RawParameter(key), value)
+            MOI.set(optimizer, MOI.RawParameter(String(key)), value)
         end
         return optimizer
     end


### PR DESCRIPTION
Passing parameters through the constructor triggered a deprecation warning about MOI.RawParameter, which is not helpful for users.

CC @odow @blegat 